### PR TITLE
Added regex to findText

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vscode-modal-editor",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "axios": "^0.27.2"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -72,11 +72,11 @@ async function importPreset(directory?: string) {
 			path: vscode.Uri.joinPath(dir, name),
 			label: name
 		}));
-	
+
 	const choice = await vscode.window.showQuickPick(files, {
 		placeHolder: "Warning: importing keybindings will overwrite current ones in settings.json"
 	});
-	
+
 	if (choice) {
 		await loadKeybindings(choice.path);
 	}
@@ -97,7 +97,7 @@ async function importKeybindings() {
 			type: "uri"
 		}
 	];
-	
+
 	const choice = await vscode.window.showQuickPick(choices, {
 		placeHolder: "Warning: importing keybindings will overwrite current ones in settings.json"
 	});
@@ -108,7 +108,7 @@ async function importKeybindings() {
 				title: "Import keybindings from file",
 				openLabel: "Import",
 				filters: {
-				  "Keybindings": ["json", "jsonc", "js"]
+					"Keybindings": ["json", "jsonc", "js"]
 				},
 				canSelectFiles: true,
 				canSelectFolders: false,
@@ -130,7 +130,7 @@ async function importKeybindings() {
 			}
 			break;
 		}
-		
+
 		case "preset": {
 			await importPreset();
 			break;
@@ -248,7 +248,7 @@ export function gotoLine(num: number) {
 	if (editor) {
 		const lineCount = editor.document.lineCount;
 		const line = num < lineCount ? num : lineCount;
-		const range = editor.document.lineAt(line-1).range;
+		const range = editor.document.lineAt(line - 1).range;
 		// go to the start of that line
 		editor.selection = new vscode.Selection(range.start, range.start);
 		editor.revealRange(range);
@@ -257,7 +257,7 @@ export function gotoLine(num: number) {
 
 /**
  * Args for findText command
- * 
+ *
  * @see {isFindTextArgs} ts-auto-guard:type-guard
  */
 export type FindTextArgs = {
@@ -271,6 +271,8 @@ export type FindTextArgs = {
 	withinLine?: boolean,
 	/// Search backward (default: false)
 	backward?: boolean,
+	/// Whether to search using regex (default: false)
+	regex?: boolean,
 };
 
 /**
@@ -287,6 +289,29 @@ export function findText(args: FindTextArgs) {
 		return;
 	}
 
+	// Find the next index given a regex
+	const regexIndexOf = (str: string, regex: string, pos?: number | undefined) => {
+		pos = pos || 0;
+
+		// Search forward from position in string
+		let indexOf = str.substring(pos).search(RegExp(regex));
+
+		// Add position to found index to account for beginning of string
+		return (indexOf >= 0) ? (indexOf + pos) : indexOf;
+	}
+
+	// Find the previous index given a regex
+	const regexLastIndexOf = (str: string, regex: string, pos?: number | undefined) => {
+		pos = pos || str.length;
+
+		// Reverse the string and search for first occurrence
+		let strReversed = str.substring(0, pos).split("").reverse().join("");
+		let indexOfReversed = strReversed.search(RegExp(regex));
+
+		// Compute un-reversed position
+		return (indexOfReversed >= 0) ? (pos - indexOfReversed - 1) : indexOfReversed;
+	}
+
 	// Update a selection to a pos
 	const updateSel = (sel: vscode.Selection, lineNum: number, pos: number) => {
 		let newPos = new vscode.Position(lineNum, pos);
@@ -294,7 +319,7 @@ export function findText(args: FindTextArgs) {
 		// Add one if the range is not inclusive
 		if (!args.backward && !appState.config.misc.inclusiveRange)
 			newPos = newPos.translate(0, 1);
-		
+
 		// Move to the text instead of till the text
 		if (args.till)
 			newPos = newPos.translate(0, args.backward ? 1 : -1);
@@ -313,39 +338,46 @@ export function findText(args: FindTextArgs) {
 		// Set the pos to the cursor
 		const curPos = sel.active;
 		const curLine = editor.document.lineAt(curPos.line);
-		const pos = args.backward ?
-			curLine.text.lastIndexOf(args.text, curPos.character-1) :
-			curLine.text.indexOf(args.text, curPos.character+1);
-		
+
+		// Set the indexOf method (used for current line and looping later)
+		let indexOf;
+		if (args.backward && args.regex) {
+			indexOf = regexLastIndexOf;
+		} else if (args.backward && !args.regex) {
+			indexOf = (str: string, text: string, pos?: number) => { return str.lastIndexOf(text, pos); }
+		} else if (!args.backward && args.regex) {
+			indexOf = regexIndexOf;
+		} else { // !args.backward && !args.regex
+			indexOf = (str: string, text: string, pos?: number) => { return str.indexOf(text, pos); }
+		}
+
+		// An annoying difference between lastIndexOf and regexLastIndexOf
+		let offset = (args.backward && args.regex) ? 0 : (args.backward ? -1 : 1);
+		let pos = indexOf(curLine.text, args.text, curPos.character + offset);
+
 		if (pos >= 0) {
 			return updateSel(sel, curLine.lineNumber, pos);
 		}
 
 		/** Find line by line (because of VSCode API limitation) */
 		if (!args.withinLine) {
-			if (args.backward) {
-				const start = curLine.lineNumber - 1; 
-				const end = 0;
-				for (let l = start; l >= end; l--) {
-					const line = editor.document.lineAt(l);
-					const pos = line.text.lastIndexOf(args.text);
-					if (pos >= 0) {
-						return updateSel(sel, l, pos);
-					}
+			const start = curLine.lineNumber + (args.backward ? - 1 : 1);
+			const end = args.backward ? 0 : editor.document.lineCount;
+
+			let l = start;
+			while ((args.backward && l >= end) || (!args.backward && l < end)) {
+				const line = editor.document.lineAt(l);
+
+				const pos = indexOf(line.text, args.text);
+
+				if (pos >= 0) {
+					return updateSel(sel, l, pos);
 				}
-			}
-			else {
-				const start = curLine.lineNumber + 1; 
-				const end = editor.document.lineCount;
-				for (let l = start; l < end; l++) {
-					const line = editor.document.lineAt(l);
-					const pos = line.text.indexOf(args.text);
-					if (pos >= 0) {
-						return updateSel(sel, l, pos);
-					}
-				}
+
+				l = l + (args.backward ? -1 : 1);
 			}
 		}
+
 		// Without modifying it
 		return sel;
 	};
@@ -473,7 +505,7 @@ export async function paste(args?: PasteArgs) {
 			getSelections(editor)
 				.forEach((selection, i) => {
 					let pos = args?.before ? selection.start : selection.end;
-					const text = texts[Math.min(i, texts.length-1)];
+					const text = texts[Math.min(i, texts.length - 1)];
 
 					// paste in previous or next line if content ends with newline
 					// (which means copy a line)
@@ -493,7 +525,7 @@ export async function paste(args?: PasteArgs) {
 							pos = curLine.end;
 						}
 					}
-					
+
 					editBuilder.insert(pos, text);
 				});
 		});
@@ -657,7 +689,7 @@ export function register(context: vscode.ExtensionContext, outputChannel: vscode
 		// Handle type events
 		vscode.commands.registerCommand("type", onType)
 	);
-		
+
 	const config = readConfig();
 	const modeStatusBar = vscode.window.createStatusBarItem(
 		vscode.StatusBarAlignment.Left,
@@ -669,4 +701,3 @@ export function register(context: vscode.ExtensionContext, outputChannel: vscode
 	);
 	appState = new AppState(NORMAL, config, outputChannel, modeStatusBar, keyStatusBar);
 }
-

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -296,7 +296,7 @@ export function findText(args: FindTextArgs) {
 		pos = pos || 0;
 
 		// Search forward from position in string
-		let index = str.substring(pos).search(regex);
+		let index = str.substring(pos).search(RegExp(regex));
 
 		// Add position to found index to account for beginning of string
 		return (index >= 0) ? (index + pos) : index;


### PR DESCRIPTION
Hello,

I added regex support to `findText`. I found this useful for (for example):

- jumping to the next text prior to calling `editor.emmet.action.decrementNumberByOne`
- enable selecting a sentence (jump left to punctuation or newline, then select right to punctuation or newline)
- enable selecting an argument/parameter (jump left to comma or paren, then select right till comma or paren)

```js
"-": [
	{
		command: "modalEditor.findText",
		computedArgs: false,
		args: { text: "[0-9]", select: false, backward: false, regex: true }
	},
	"editor.emmet.action.decrementNumberByOne",
	"cursorLeft"
],
```

Feel free to ignore, change, or move the code into a new function as you want.