### PR TITLE
Add setting for remote configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "Keymaps",
     "Other"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "keywords": [
     "modal",
     "editor",


### PR DESCRIPTION
The extension does not currently operate when using remote development extensions (e.g., Remote SSH). Adding setting "extensionKind" to `[ui, workspace]` ensures that the extension will still run using the local configuration file by default.