### PR TITLE
fix: update 'a' behavior in select mode

### DIFF
--- a/presets/helix.js
+++ b/presets/helix.js
@@ -106,8 +106,8 @@ module.exports = {
 			"modalEditor.setInsertMode"
 		]),
 		a: recordChange([
-			"cursorRight",
-			"modalEditor.setInsertMode"
+			"modalEditor.setInsertMode",
+			"cursorRight"
 		]),
 		A: recordChange([
 			"cursorLineEnd",


### PR DESCRIPTION
() represents position of block cursor in normal/select mode, | is position of line cursor in insert mode

with the helix preset starting in normal mode, given: `(x)y` I expect `v → a` to result in `xy|` but it instead results in `x|y`. 

This appears to be because `cursorRight` while there's a selection cancels the selection without actually updating the position of the cursor.