### PR TITLE
Added `languageId` to `_ctx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ type Context = {
 	selection: vscode.Selection | undefined,
 	// current selections
 	selections: readonly vscode.Selections[] | undefined
+	// language Id of current document
+	languageId: string | undefined,
 };
 ```
 
@@ -372,4 +374,3 @@ The logo of this extension is modified based on the icon credited to
 Copyright (C) 2022 DCsunset
 
 Licensed under the [AGPLv3](LICENSE) license.
-

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -53,7 +53,7 @@ export type ComplexCommand = {
 
 /**
  * Context for eval js expressions
- * 
+ *
  * @see {isCommandContext} ts-auto-guard:type-guard
  */
 export type CommandContext = {
@@ -93,7 +93,7 @@ export class AppState {
 	anchors: vscode.Position[];
 	/// selection before last command
 	lastSelections: readonly vscode.Selection[] | undefined;
-	
+
 	constructor(
 		mode: string,
 		public config: Config,
@@ -131,17 +131,17 @@ export class AppState {
 		};
 		this.setMode(this.config.misc.defaultMode);
 	}
-	
+
 	log(message: string) {
 		this.outputChannel.appendLine(message);
 	}
-	
+
 	/// Reset internal state
 	reset() {
 		this.keyEventHandler.reset();
 		this.updateStatus(vscode.window.activeTextEditor);
 	}
-	
+
 	setMode(mode: string) {
 		this.mode = mode;
 		this.updateStatus(vscode.window.activeTextEditor);
@@ -169,7 +169,7 @@ export class AppState {
 			this.setMode(NORMAL);
 		}
 	}
-	
+
 	async handleKey(key: string) {
 		try {
 			if (this.mode === INSERT) {
@@ -221,7 +221,7 @@ export class AppState {
 				this.setMode(NORMAL);
 		}
 	}
-	
+
 	/**
 	 * Execute a command with a context
 	 */
@@ -267,7 +267,7 @@ export class AppState {
 			vscode.window.showErrorMessage(`Invalid command: ${command}`);
 		}
 	}
-	
+
 	/**
 	 * jsEval evaluates JS expressions
 	 */
@@ -291,11 +291,13 @@ export class AppState {
 			selection: editor?.selection,
 			// current selections
 			selections: editor?.selections,
+			// language Id of current document
+			languageId: editor?.document.languageId,
 		};
 
 		return eval(`(${expressions})`);
 	}
-	
+
 	async executeVSCommand(command: string, ...rest: any[]) {
 		const editor = vscode.window.activeTextEditor;
 		this.lastSelections = editor?.selections;
@@ -307,5 +309,3 @@ export class AppState {
 		}
 	}
 }
-
-


### PR DESCRIPTION
This PR addresses #6 

(Sorry for removing trailing whitespace. I hope that isn't too annoying.)

I've added `languageId` from the [`TextDocument`](https://code.visualstudio.com/api/references/vscode-api#TextDocument) object to the `_ctx` object.

If you'd like, I can also add an example to the keymap in the readme. Something like this:

```javascript
" ": {
	"b": [
		{ command: "latex-workshop.build", when: "_ctx.languageId == 'latex'" },
		{ command: "workbench.action.tasks.build", when: "_ctx.languageId != 'latex'" },
	],
}
```

This is a simple change that I think will work for most cases. I do wonder, though, if it would be better to add a more complex feature. One downside of the current approach is that you can't really have a catch-all option (use this command when none of the other commands were executed).