### PR TITLE
Allow multi-cursor selections via Helix-style `s` inside a selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ They are listed as follows:
 | `modalEditor.setInsertMode` | - | Set to insert mode (and clear selections if `clearSelectionsOnInsertMode` is enabled) |
 | `modalEditor.setNormalMode` | - | Set to normal mode |
 | `modalEditor.setSelectMode` | - | Set to select mode |
+| `modalEditor.setSelectionSearchMode` | - | Set to search-within-a-selection mode |
 | `modalEditor.setCommandMode` | - | Set to command mode |
 | `modalEditor.setKeys` | `string` | Change current key sequence without applying it. Value should be a js expression (useful for modifying unexecuted commands) |
 | `modalEditor.gotoLine` | `number` | Go to the specified line |
@@ -192,12 +193,14 @@ Available cursor styles can be found [here](https://github.com/microsoft/vscode/
 
 ### Basics
 
-There are 4 predefined modes (`normal`, `insert`, `select`, `command`) in this extension,
-but you are free to add more modes.
+There are 5 predefined modes (`normal`, `insert`, `select`, `selectionSearch`,
+and `command`) in this extension, but you are free to add more modes.
 Note that the mode name shouldn't start with underscore `_` as it is reserved for other config.
 
-Keybindings can be defined for all modes except for insert mode,
-because this extension will handle over to VS Code in insert mode.
+Keybindings can be defined for all modes except for insert mode and
+selection search mode. In insert mode this extension will handle over to
+VS Code, whereas in selection search input is reserved to type in the
+regular expression to search with.
 
 Each key sequence can be prefixed with a number indicating the count.
 The count value will be stored in the `CommandContext`,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
         "title": "Modal Editor: Set mode to command"
       },
       {
+        "command": "modalEditor.setSelectionSearchMode",
+        "title": "Modal Editor: Set mode to search within a selection"
+      },
+      {
         "command": "modalEditor.importKeybindings",
         "title": "Modal Editor: Import keybindings"
       },
@@ -176,6 +180,24 @@
         "command": "modalEditor.setKeys",
         "args": "_ctx.keys.substring(0, _ctx.keys.length-1)",
         "when": "editorTextFocus && modalEditor.mode == 'command'"
+      },
+      {
+        "key": "backspace",
+        "command": "type",
+        "args": { "text": "\b" },
+        "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
+      },
+      {
+        "key": "escape",
+        "command": "type",
+        "args": { "text": "\u001b" },
+        "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
+      },
+      {
+        "key": "enter",
+        "command": "type",
+        "args": { "text": "\n" },
+        "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,18 @@
         "title": "Modal Editor: Set mode to search within a selection"
       },
       {
+        "command": "modalEditor.navigateToNextSelection",
+        "title": "Modal Editor: Navigate to next selection"
+      },
+      {
+        "command": "modalEditor.navigateToPreviousSelection",
+        "title": "Modal Editor: Navigate to previous selection"
+      },
+      {
+        "command": "modalEditor.unselectPrimarySelection",
+        "title": "Modal Editor: Unselect primary selection"
+      },
+      {
         "command": "modalEditor.importKeybindings",
         "title": "Modal Editor: Import keybindings"
       },
@@ -198,6 +210,11 @@
         "command": "type",
         "args": { "text": "\n" },
         "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
+      },
+      {
+        "key": "alt+,",
+        "command": "modalEditor.unselectPrimarySelection",
+        "when": "editorTextFocus && (modalEditor.mode == 'normal' || modalEditor.mode == 'select')"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -212,6 +212,12 @@
         "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
       },
       {
+        "key": "delete",
+        "command": "type",
+        "args": { "text": "\u007f" },
+        "when": "editorTextFocus && modalEditor.mode == 'selectionSearch'"
+      },
+      {
         "key": "alt+,",
         "command": "modalEditor.unselectPrimarySelection",
         "when": "editorTextFocus && (modalEditor.mode == 'normal' || modalEditor.mode == 'select')"

--- a/presets/helix.js
+++ b/presets/helix.js
@@ -32,7 +32,7 @@ const recordChange = command => record(command, "change");
 const recordMotion = command => record(command, "motion");
 
 module.exports = {
-	// Common keybindings (except for insert mode)
+	// Common keybindings (except for insert and selectionSearch modes)
 	"": {
 		u: repeatable("undo"),
 		U: repeatable("redo"),
@@ -319,7 +319,10 @@ module.exports = {
 		},
 	
 		// set to select mode
-		v: "modalEditor.setSelectMode"
+		v: "modalEditor.setSelectMode",
+
+		// enter selection search mode
+		s: "modalEditor.setSelectionSearchMode"
 	},
 
 	select: {
@@ -398,7 +401,10 @@ module.exports = {
 		},
 	
 		// set back to normal mode
-		v: "modalEditor.setNormalMode"
+		v: "modalEditor.setNormalMode",
+
+		// enter selection search mode
+		s: "modalEditor.setSelectionSearchMode"
 	},
 
 	// Command mode

--- a/presets/helix.js
+++ b/presets/helix.js
@@ -322,7 +322,14 @@ module.exports = {
 		v: "modalEditor.setSelectMode",
 
 		// enter selection search mode
-		s: "modalEditor.setSelectionSearchMode"
+		s: "modalEditor.setSelectionSearchMode",
+
+		// navigate between selections
+		"(": "modalEditor.navigateToPreviousSelection",
+		")": "modalEditor.navigateToNextSelection",
+
+		// unselect primary selection (Alt+, platform dependent)
+		"≤": "modalEditor.unselectPrimarySelection"
 	},
 
 	select: {
@@ -404,7 +411,14 @@ module.exports = {
 		v: "modalEditor.setNormalMode",
 
 		// enter selection search mode
-		s: "modalEditor.setSelectionSearchMode"
+		s: "modalEditor.setSelectionSearchMode",
+
+		// navigate between selections
+		"(": "modalEditor.navigateToPreviousSelection",
+		")": "modalEditor.navigateToNextSelection",
+
+		// unselect primary selection (Alt+, platform dependent)
+		"≤": "modalEditor.unselectPrimarySelection"
 	},
 
 	// Command mode

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -400,7 +400,7 @@ export class AppState {
 
 		let regex: RegExp;
 		try {
-			regex = new RegExp(this.selectionSearchPattern, 'g');
+			regex = new RegExp(this.selectionSearchPattern, 'gm');
 		} catch (error) {
 			if (this.originalSelections) {
 				editor.selections = Array.from(this.originalSelections);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -427,6 +427,7 @@ export class AppState {
 		// Update editor selections
 		if (newSelections.length > 0) {
 			editor.selections = newSelections;
+			editor.revealRange(newSelections[0], vscode.TextEditorRevealType.InCenterIfOutsideViewport);
 			this.updateSearchStatus(undefined, newSelections.length);
 		} else {
 			// No matches found - restore original selections

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -98,6 +98,11 @@ export class AppState {
 	selectionSearchPattern: string;
 	/// original selections before entering selection search
 	originalSelections: readonly vscode.Selection[] | undefined;
+	/// index of primary selection for multi-selection navigation
+	primarySelectionIndex: number;
+	/// decorations for primary and secondary selections
+	primarySelectionDecoration: vscode.TextEditorDecorationType | undefined;
+	secondarySelectionDecoration: vscode.TextEditorDecorationType | undefined;
 
 	constructor(
 		mode: string,
@@ -111,6 +116,8 @@ export class AppState {
 		this.anchors = [];
 		this.selectionSearchPattern = "";
 		this.originalSelections = undefined;
+		this.primarySelectionIndex = 0;
+		this.initializeDecorations();
 		this.setMode(mode);
 	}
 
@@ -163,6 +170,8 @@ export class AppState {
 	}
 
 	setMode(mode: string) {
+		// Clear decorations when leaving any mode
+		this.clearSelectionDecorations();
 		this.mode = mode;
 		this.updateStatus(vscode.window.activeTextEditor);
 		if (mode === SELECT) {
@@ -427,7 +436,14 @@ export class AppState {
 		// Update editor selections
 		if (newSelections.length > 0) {
 			editor.selections = newSelections;
+			// Reset primary selection to first result
+			this.primarySelectionIndex = 0;
+			// Ensure the first selection is visible
 			editor.revealRange(newSelections[0], vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+			// Update decorations for multiple selections
+			if (newSelections.length > 1) {
+				this.updateSelectionDecorations();
+			}
 			this.updateSearchStatus(undefined, newSelections.length);
 		} else {
 			// No matches found - restore original selections
@@ -461,5 +477,116 @@ export class AppState {
 			? `SEL: ${this.selectionSearchPattern} (${error})`
 			: `SEL: ${this.selectionSearchPattern} (${actualMatchCount} matches)`;
 		this.modeStatusBar.text = statusText;
+	}
+
+	initializeDecorations() {
+		this.primarySelectionDecoration = vscode.window.createTextEditorDecorationType({
+			backgroundColor: new vscode.ThemeColor('editor.selectionBackground'),
+			border: '2px solid',
+			borderColor: new vscode.ThemeColor('editor.selectionForeground')
+		});
+
+		this.secondarySelectionDecoration = vscode.window.createTextEditorDecorationType({
+			backgroundColor: new vscode.ThemeColor('editor.inactiveSelectionBackground'),
+			border: '1px solid',
+			borderColor: new vscode.ThemeColor('editor.selectionForeground')
+		});
+	}
+
+	updateSelectionDecorations() {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.selections.length <= 1) {
+			return;
+		}
+
+		const primaryRanges: vscode.Range[] = [];
+		const secondaryRanges: vscode.Range[] = [];
+
+		editor.selections.forEach((selection, index) => {
+			if (index === this.primarySelectionIndex) {
+				primaryRanges.push(selection);
+			} else {
+				secondaryRanges.push(selection);
+			}
+		});
+
+		if (this.primarySelectionDecoration) {
+			editor.setDecorations(this.primarySelectionDecoration, primaryRanges);
+		}
+		if (this.secondarySelectionDecoration) {
+			editor.setDecorations(this.secondarySelectionDecoration, secondaryRanges);
+		}
+	}
+
+	clearSelectionDecorations() {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return;
+		}
+
+		if (this.primarySelectionDecoration) {
+			editor.setDecorations(this.primarySelectionDecoration, []);
+		}
+		if (this.secondarySelectionDecoration) {
+			editor.setDecorations(this.secondarySelectionDecoration, []);
+		}
+	}
+
+	navigateToNextSelection() {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.selections.length <= 1) {
+			return;
+		}
+
+		this.primarySelectionIndex = (this.primarySelectionIndex + 1) % editor.selections.length;
+		this.updateSelectionDecorations();
+
+		// Ensure the primary selection is visible
+		const primarySelection = editor.selections[this.primarySelectionIndex];
+		editor.revealRange(primarySelection, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+	}
+
+	navigateToPreviousSelection() {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.selections.length <= 1) {
+			return;
+		}
+
+		this.primarySelectionIndex = this.primarySelectionIndex === 0
+			? editor.selections.length - 1
+			: this.primarySelectionIndex - 1;
+		this.updateSelectionDecorations();
+
+		// Ensure the primary selection is visible
+		const primarySelection = editor.selections[this.primarySelectionIndex];
+		editor.revealRange(primarySelection, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+	}
+
+	unselectPrimarySelection() {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.selections.length <= 1) {
+			return;
+		}
+
+		const newSelections = editor.selections.filter((_, index) => index !== this.primarySelectionIndex);
+		editor.selections = newSelections;
+
+		// Adjust primary selection index
+		if (this.primarySelectionIndex >= newSelections.length) {
+			this.primarySelectionIndex = Math.max(0, newSelections.length - 1);
+		}
+
+		this.updateSelectionDecorations();
+
+		// Ensure the new primary selection is visible if any selections remain
+		if (newSelections.length > 0) {
+			const primarySelection = newSelections[this.primarySelectionIndex];
+			editor.revealRange(primarySelection, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+		}
+	}
+
+	dispose() {
+		this.primarySelectionDecoration?.dispose();
+		this.secondarySelectionDecoration?.dispose();
 	}
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -15,6 +15,7 @@ export const NORMAL = "normal";
 export const INSERT = "insert";
 export const SELECT = "select";
 export const COMMAND = "command";
+export const SELECTION_SEARCH = "selectionSearch";
 
 /**
  * Command types:
@@ -93,6 +94,10 @@ export class AppState {
 	anchors: vscode.Position[];
 	/// selection before last command
 	lastSelections: readonly vscode.Selection[] | undefined;
+	/// selection search state
+	selectionSearchPattern: string;
+	/// original selections before entering selection search
+	originalSelections: readonly vscode.Selection[] | undefined;
 
 	constructor(
 		mode: string,
@@ -104,6 +109,8 @@ export class AppState {
 		this.registers = {};
 		this.records = {};
 		this.anchors = [];
+		this.selectionSearchPattern = "";
+		this.originalSelections = undefined;
 		this.setMode(mode);
 	}
 
@@ -113,8 +120,11 @@ export class AppState {
 			const { cursorStyle, statusText } = getStyle(this.mode, this.config.styles);
 			// default cursorStyle
 			editor.options.cursorStyle = cursorStyleMap[cursorStyle || "block"];
-			// default statusText
-			this.modeStatusBar.text = statusText || `-- ${this.mode.toUpperCase()} --`;
+			if (this.mode !== SELECTION_SEARCH) {
+				// default statusText (except for selection search mode that has its own status)
+				this.modeStatusBar.text = statusText || `-- ${this.mode.toUpperCase()} --`;
+			}
+
 			this.modeStatusBar.show();
 			this.keyStatusBar.show();
 		}
@@ -142,23 +152,41 @@ export class AppState {
 		this.updateStatus(vscode.window.activeTextEditor);
 	}
 
+	statusBarForMode(mode: string): vscode.StatusBarItem {
+		switch (mode) {
+			case COMMAND:
+			case SELECTION_SEARCH:
+				return this.modeStatusBar;
+			default:
+				return this.keyStatusBar;
+		}
+	}
+
 	setMode(mode: string) {
 		this.mode = mode;
 		this.updateStatus(vscode.window.activeTextEditor);
 		if (mode === SELECT) {
 			// record anchor
 			this.anchors = vscode.window.activeTextEditor?.selections.map(sel => sel.anchor) ?? [];
+		} else if (mode === SELECTION_SEARCH) {
+			// record original selections before making new ones during search
+			this.originalSelections = vscode.window.activeTextEditor?.selections;
+			this.selectionSearchPattern = "";
 		}
 		this.keyEventHandler = new KeyEventHandler(
-			mode === COMMAND ? this.modeStatusBar : this.keyStatusBar,
+			this.statusBarForMode(mode),
 			// keymap in this mode
 			this.config.keybindings[mode],
 			// common keymap
 			this.config.keybindings[""],
 			// whether it's command mode
 			mode === COMMAND,
-      this.config.misc.parseNumberPrefix
+			this.config.misc.parseNumberPrefix
 		);
+
+		if (mode === SELECTION_SEARCH) {
+			this.updateSearchStatus();
+		}
 	}
 
 	async replayRecord(reg: string) {
@@ -184,6 +212,12 @@ export class AppState {
 				vscode.commands.executeCommand("default:type", {
 					text: key
 				});
+				return;
+			}
+
+			if (this.mode === SELECTION_SEARCH) {
+				// Handle selection search input
+				await this.handleSelectionSearchKey(key);
 				return;
 			}
 
@@ -308,5 +342,123 @@ export class AppState {
 		catch (error: any) {
 			vscode.window.showErrorMessage(error.message);
 		}
+	}
+
+	async handleSelectionSearchKey(key: string) {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || !this.originalSelections) {
+			return;
+		}
+
+		switch (key) {
+			case '\n':
+			case '\r':
+				// Enter key - confirm search and exit to normal mode
+				this.setMode(NORMAL);
+				return;
+			case '\u001b':
+				// Escape key - cancel search and restore original selections
+				if (this.originalSelections) {
+					editor.selections = Array.from(this.originalSelections);
+				}
+				this.setMode(NORMAL);
+				return;
+			case '\b':
+			case '\u007f':
+				// Backspace or Delete - remove last character
+				if (this.selectionSearchPattern.length > 0) {
+					this.selectionSearchPattern = this.selectionSearchPattern.slice(0, -1);
+					this.updateSelectionSearch(editor);
+				}
+				return;
+			default:
+				// Regular character - add to pattern
+				this.selectionSearchPattern += key;
+				this.updateSelectionSearch(editor);
+				return;
+		}
+	}
+
+	updateSelectionSearch(editor: vscode.TextEditor) {
+		// If no pattern, restore original selections
+		if (!this.originalSelections || this.selectionSearchPattern === "") {
+			if (this.originalSelections) {
+				editor.selections = Array.from(this.originalSelections);
+			}
+			this.updateSearchStatus();
+			return;
+		}
+
+		let regex: RegExp;
+		try {
+			regex = new RegExp(this.selectionSearchPattern, 'g');
+		} catch (error) {
+			if (this.originalSelections) {
+				editor.selections = Array.from(this.originalSelections);
+			}
+			this.updateSearchStatus("invalid regex");
+			return;
+		}
+
+		const newSelections: vscode.Selection[] = [];
+
+		// Search within each original selection
+		for (const originalSel of this.originalSelections) {
+			const text = editor.document.getText(originalSel);
+			let match;
+			regex.lastIndex = 0; // Reset regex state
+
+			while ((match = regex.exec(text)) !== null) {
+				// Calculate absolute positions
+				const startOffset = editor.document.offsetAt(originalSel.start) + match.index;
+				const endOffset = startOffset + Math.max(0, match[0].length - 1);
+				const startPos = editor.document.positionAt(startOffset);
+				const endPos = editor.document.positionAt(endOffset);
+				if (match[0].length > 0) {
+					newSelections.push(new vscode.Selection(startPos, endPos));
+				}
+				else {
+					// Prevent infinite loop with zero-length matches
+					regex.lastIndex = match.index + 1;
+				}
+			}
+		}
+
+		// Update editor selections
+		if (newSelections.length > 0) {
+			editor.selections = newSelections;
+			this.updateSearchStatus(undefined, newSelections.length);
+		} else {
+			// No matches found - restore original selections
+			if (this.originalSelections) {
+				editor.selections = Array.from(this.originalSelections);
+			}
+			this.updateSearchStatus(undefined, 0);
+		}
+	}
+
+	updateSearchStatus(error?: string, matchCount?: number) {
+		if (this.mode !== SELECTION_SEARCH) {
+			return;
+		}
+
+		const editor = vscode.window.activeTextEditor;
+		let actualMatchCount = 0;
+		if (matchCount === undefined) {
+			if (this.selectionSearchPattern === "") {
+				error = "enter regex";
+			}
+			else if (editor && editor.selections) {
+				actualMatchCount = editor.selections.length;
+			}
+		}
+		else {
+			actualMatchCount = matchCount;
+		}
+
+		const statusText = error
+			? `SEL: ${this.selectionSearchPattern} (${error})`
+			: `SEL: ${this.selectionSearchPattern} (${actualMatchCount} matches)`;
+		this.modeStatusBar.text = statusText;
 	}
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { expandHome, loadKeybindings, readConfig } from "./config";
-import { AppState, NORMAL, INSERT, SELECT, COMMAND, Command } from "./actions";
+import { AppState, NORMAL, INSERT, SELECT, COMMAND, SELECTION_SEARCH, Command } from "./actions";
 import { isCommand } from "./actions.guard";
 import { isFindTextArgs, isYankArgs, isPasteArgs, isTransformArgs } from "./commands.guard";
 
@@ -196,6 +196,10 @@ export async function setSelectMode() {
 
 export async function setCommandMode() {
 	await setMode(COMMAND);
+}
+
+export async function setSelectionSearchMode() {
+	await setMode(SELECTION_SEARCH);
 }
 
 /**
@@ -672,6 +676,7 @@ export async function register(context: vscode.ExtensionContext, outputChannel: 
 		registerCommand(setNormalMode),
 		registerCommand(setSelectMode),
 		registerCommand(setCommandMode),
+		registerCommand(setSelectionSearchMode),
 		registerCommand(setKeys),
 		registerCommand(gotoLine),
 		registerCommand(findText),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -202,6 +202,18 @@ export async function setSelectionSearchMode() {
 	await setMode(SELECTION_SEARCH);
 }
 
+export function navigateToNextSelection() {
+	appState.navigateToNextSelection();
+}
+
+export function navigateToPreviousSelection() {
+	appState.navigateToPreviousSelection();
+}
+
+export function unselectPrimarySelection() {
+	appState.unselectPrimarySelection();
+}
+
 /**
  * Change the current key sequence but not applying them
  * Arg is a js expression
@@ -677,6 +689,9 @@ export async function register(context: vscode.ExtensionContext, outputChannel: 
 		registerCommand(setSelectMode),
 		registerCommand(setCommandMode),
 		registerCommand(setSelectionSearchMode),
+		registerCommand(navigateToNextSelection),
+		registerCommand(navigateToPreviousSelection),
+		registerCommand(unselectPrimarySelection),
 		registerCommand(setKeys),
 		registerCommand(gotoLine),
 		registerCommand(findText),


### PR DESCRIPTION
Thanks for the extension, it works great! The one feature that I was missing from Helix was doing search/replaces straight from selections. Hopefully this is in line with your goals for the plugin.

![2025-06-09 15 25 38](https://github.com/user-attachments/assets/caf17790-16f4-4b62-8cc0-17db8ec21fd3)
